### PR TITLE
Fix missing permissions in github publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Fix the missing permission on id-token for the uv publish command in github action.