### PR TITLE
Add OverlayFormat for customising overlays

### DIFF
--- a/compuglobal/__init__.py
+++ b/compuglobal/__init__.py
@@ -13,6 +13,7 @@ from compuglobal.models.comic import ComicLayout, ComicOverlay, ComicPanel, Comi
 from compuglobal.models.episode import Episode, EpisodeMetadata, EpisodeSummary
 from compuglobal.models.font import FontAlignment, FontColorRGB, FontFamily
 from compuglobal.models.frame import Frame, FrameResult
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.stream import Stream, StreamOverlay
 from compuglobal.models.subtitle import Subtitle
@@ -43,6 +44,7 @@ __all__ = [
     "MasterOfAllScience",
     "Morbotron",
     "NoSearchResultsFoundError",
+    "OverlayFormat",
     "Screencap",
     "ScreencapMoment",
     "Stream",

--- a/compuglobal/aio.py
+++ b/compuglobal/aio.py
@@ -15,6 +15,7 @@ from compuglobal.models.comic import ComicPanel, ComicStrip
 from compuglobal.models.episode import Episode, EpisodeSummary
 from compuglobal.models.font import FontFamily
 from compuglobal.models.frame import Frame, FrameResult
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.stream import Stream
 from compuglobal.models.subtitle import Subtitle
@@ -27,7 +28,7 @@ class AsyncCompuGlobalAPI:
 
     BASE_URL: str
     TITLE: str
-    DEFAULT_FONT: FontFamily
+    DEFAULT_FORMAT: OverlayFormat
     _MAX_ALLOWED_SUBTITLES = 4
 
     discovery: DiscoveryAPI = DiscoveryAPI()
@@ -44,7 +45,7 @@ class AsyncCompuGlobalAPI:
 
         """
         self.client = CompuGlobalAPIClient(base_url=self.BASE_URL, session=session)
-        self.config = CompuGlobalAPIConfig(title=self.TITLE, default_font=self.DEFAULT_FONT)
+        self.config = CompuGlobalAPIConfig(title=self.TITLE, default_format=self.DEFAULT_FORMAT)
 
     async def get_screencap(
         self,
@@ -304,7 +305,7 @@ class AsyncCompuGlobalAPI:
 
         screencap = screencap.model_copy(update={"subtitles": subtitles})
 
-        panel = ComicPanel.from_screencap(screencap=screencap, font=self.config.default_font)
+        panel = ComicPanel.from_screencap(screencap=screencap, overlay_format=self.config.default_format)
 
         params = {"b64": panel.get_encoded()}
         return self.media.COMIC_PANEL.build_encoded_url(self.client.base_url, query=params)
@@ -334,7 +335,7 @@ class AsyncCompuGlobalAPI:
         # Change subtitles
         screencap = screencap.model_copy(update={"subtitles": subtitles})
 
-        comic_strip = ComicStrip.from_screencap(screencap=screencap, font_family=self.config.default_font)
+        comic_strip = ComicStrip.from_screencap(screencap=screencap, overlay_format=self.config.default_format)
         params = {"b64": comic_strip.get_encoded(), "layout": comic_strip.layout}
         return self.media.COMIC_STRIP.build_encoded_url(self.client.base_url, query=params)
 
@@ -363,7 +364,7 @@ class AsyncCompuGlobalAPI:
         # Change subtitles
         screencap = screencap.model_copy(update={"subtitles": subtitles})
 
-        stream = Stream.from_screencap(screencap=screencap, font_family=self.config.default_font)
+        stream = Stream.from_screencap(screencap=screencap, overlay_format=self.config.default_format)
 
         request = self.media.RENDER_GIF.build_request(self.client.base_url, body=stream)
         request.body = [request.body]
@@ -383,7 +384,7 @@ class CapitalBeatUs(AsyncCompuGlobalAPI):
 
     BASE_URL = "https://capitalbeat.us"
     TITLE = "West Wing"
-    DEFAULT_FONT = FontFamily.IMPACT
+    DEFAULT_FORMAT = OverlayFormat(font_family=FontFamily.IMPACT)
 
 
 class Frinkiac(AsyncCompuGlobalAPI):
@@ -391,7 +392,7 @@ class Frinkiac(AsyncCompuGlobalAPI):
 
     BASE_URL = "https://frinkiac.com"
     TITLE = "Simpsons"
-    DEFAULT_FONT = FontFamily.AKBAR
+    DEFAULT_FORMAT = OverlayFormat(font_family=FontFamily.AKBAR)
 
 
 @deprecated("The MasterOfAllScience API is deprecated, and currently redirects to Frinkiac")
@@ -400,7 +401,7 @@ class MasterOfAllScience(AsyncCompuGlobalAPI):
 
     BASE_URL = "https://masterofallscience.com"
     TITLE = "Rick and Morty"
-    DEFAULT_FONT = FontFamily.IMPACT
+    DEFAULT_FORMAT = OverlayFormat(font_family=FontFamily.IMPACT)
 
 
 class Morbotron(AsyncCompuGlobalAPI):
@@ -408,4 +409,4 @@ class Morbotron(AsyncCompuGlobalAPI):
 
     BASE_URL = "https://morbotron.com"
     TITLE = "Futurama"
-    DEFAULT_FONT = FontFamily.FR_BOLD
+    DEFAULT_FORMAT = OverlayFormat(font_family=FontFamily.FR_BOLD)

--- a/compuglobal/api/config.py
+++ b/compuglobal/api/config.py
@@ -1,13 +1,16 @@
 """The configuration for a CGHMC API (title + font)."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from compuglobal.models.font import FontFamily
+from compuglobal.models.overlay import OverlayFormat
 
 
 @dataclass
 class CompuGlobalAPIConfig:
     """The configuration for a CompuGlobal API."""
 
+    #: The title of the API
     title: str
-    default_font: FontFamily = FontFamily.IMPACT
+
+    #: The default formatting to use in all stream/comic overlays (subtitles)
+    default_format: OverlayFormat = field(default_factory=OverlayFormat)

--- a/compuglobal/models/comic.py
+++ b/compuglobal/models/comic.py
@@ -7,6 +7,7 @@ from enum import IntEnum, StrEnum
 from pydantic import Field, model_validator
 
 from compuglobal.models.base import BaseCompuGlobalModel
+from compuglobal.models.overlay import OverlayFormat
 
 from .font import FontAlignment, FontFamily
 from .screencap import Screencap
@@ -62,7 +63,7 @@ class ComicOverlay(BaseCompuGlobalModel):
     text: str = Field(alias="t", description="Text to overlay")
     font_family: FontFamily = Field(alias="f", description="Font style to use", default=FontFamily.IMPACT)
     font_size: int = Field(alias="s", description="Size of the font", ge=0, le=120, default=0)
-    font_color: str = Field(alias="c", description="Font color to use", min_length=8, max_length=8, default="ffffffff")
+    font_color: str = Field(alias="c", description="Font color to use", min_length=8, max_length=10, default="ffffffff")
     text_position_x: int = Field(alias="x", description="The x position of the overlay", default=50)
     text_position_y: int = Field(alias="y", description="The y position of the overlay", default=97)
     text_alignment: FontAlignment = Field(
@@ -75,11 +76,39 @@ class ComicOverlay(BaseCompuGlobalModel):
     d: int = Field(alias="d", description="Duration (unused)", default=0)
 
     @classmethod
+    def build_with_format(cls, *, text: str, overlay_format: OverlayFormat) -> "ComicOverlay":
+        """Build a ComicOverlay using an OverlayFormat.
+
+        Parameters
+        ----------
+        text : str
+            The content/text of the subtitle in the overlay
+        overlay_format : OverlayFormat
+            The format to use for all formatting in the overlay
+
+        Returns
+        -------
+        ComicOverlay
+            The comic overlay with the given formatting
+
+        """
+        return cls(
+            text=text,
+            font_family=overlay_format.font_family,
+            font_color=overlay_format.font_color_hex,
+            font_size=overlay_format.font_size,
+            text_position_x=overlay_format.text_position_x,
+            text_position_y=overlay_format.text_position_y,
+            text_alignment=overlay_format.text_alignment,
+            all_caps=int(overlay_format.all_caps),
+        )
+
+    @classmethod
     def from_subtitles(
         cls,
         *,
         subtitles: list[Subtitle],
-        font_family: FontFamily = FontFamily.IMPACT,
+        overlay_format: OverlayFormat | None = None,
     ) -> "ComicOverlay":
         """Build a comic overlay using a list of Subtitles.
 
@@ -87,8 +116,8 @@ class ComicOverlay(BaseCompuGlobalModel):
         ----------
         subtitles : List[Subtitle]
             A list of subtitles
-        font_family : FontFamily, optional
-            The family of font to use for the new overlay.
+        overlay_format : OverlayFormat
+            The format to use in the overlay
 
         Returns
         -------
@@ -96,8 +125,11 @@ class ComicOverlay(BaseCompuGlobalModel):
             The overlay to display on a ComicPanel
 
         """
+        if overlay_format is None:
+            overlay_format = OverlayFormat()
+
         text = " ".join(subtitle.content for subtitle in subtitles)
-        return cls(t=text, f=font_family)
+        return cls.build_with_format(text=text, overlay_format=overlay_format)
 
 
 class ComicPanel(BaseCompuGlobalModel):
@@ -119,15 +151,21 @@ class ComicPanel(BaseCompuGlobalModel):
     overlays: list[ComicOverlay] = Field(alias="o", description="The text overlays for each panel", default=[])
 
     @classmethod
-    def from_screencap(cls, *, screencap: Screencap, font: FontFamily = FontFamily.IMPACT) -> "ComicPanel":
+    def from_screencap(
+        cls,
+        *,
+        screencap: Screencap,
+        overlay_format: OverlayFormat | None = None,
+    ) -> "ComicPanel":
         """Build a comic panel from a Screencap.
 
         Parameters
         ----------
         screencap : Screencap
             Screencap to use for the comic panel
-        font : FontFamily, optional
-            The font to use in the comic overlays
+        overlay_format : OverlayFormat | list[OverlayFormat], optional
+            The format(s) to use in the overlays. See :meth:`OverlayFormat.normalise` for
+            full details on how formats are resolved.
 
         Returns
         -------
@@ -135,7 +173,7 @@ class ComicPanel(BaseCompuGlobalModel):
             The comic panel of the screencap
 
         """
-        overlays = [ComicOverlay.from_subtitles(subtitles=screencap.subtitles, font_family=font)]
+        overlays = [ComicOverlay.from_subtitles(subtitles=screencap.subtitles, overlay_format=overlay_format)]
 
         return cls(e=screencap.frame.key, ts=screencap.frame.timestamp, o=overlays)
 
@@ -175,15 +213,21 @@ class ComicStrip(BaseCompuGlobalModel, frozen=False):
     )
 
     @classmethod
-    def from_screencap(cls, *, screencap: Screencap, font_family: FontFamily = FontFamily.IMPACT) -> "ComicStrip":
+    def from_screencap(
+        cls,
+        *,
+        screencap: Screencap,
+        overlay_format: OverlayFormat | list[OverlayFormat] | None = None,
+    ) -> "ComicStrip":
         """Build a comic strip from a Screencap object.
 
         Parameters
         ----------
         screencap : Screencap
             The screencap to use for the comic strip
-        font_family : FontFamily, optional
-            The font to use for all overlays in the comic strip
+        overlay_format : OverlayFormat | list[OverlayFormat], optional
+            The format(s) to use in the overlays. See :meth:`OverlayFormat.normalise` for
+            full details on how formats are resolved.
 
         Returns
         -------
@@ -191,13 +235,14 @@ class ComicStrip(BaseCompuGlobalModel, frozen=False):
             The comic strip depicting the given screencap
 
         """
+        overlay_formats = OverlayFormat.normalise(overlay_format, len(screencap.subtitles))
         panels = [
             ComicPanel(
                 e=screencap.frame.key,
                 ts=subtitle.representative_timestamp,
-                o=cls.build_comic_overlays([subtitle], font_family=font_family),
+                o=cls.build_comic_overlays([subtitle], overlay_format=overlay_format),
             )
-            for subtitle in screencap.subtitles
+            for subtitle, overlay_format in zip(screencap.subtitles, overlay_formats, strict=True)
         ]
 
         return cls(panels=panels)
@@ -205,7 +250,7 @@ class ComicStrip(BaseCompuGlobalModel, frozen=False):
     @staticmethod
     def build_comic_overlays(
         subtitles: list[Subtitle],
-        font_family: FontFamily = FontFamily.IMPACT,
+        overlay_format: OverlayFormat | list[OverlayFormat] | None = None,
     ) -> list[ComicOverlay]:
         """Build a list comic overlays using the given subtitles and font.
 
@@ -213,8 +258,9 @@ class ComicStrip(BaseCompuGlobalModel, frozen=False):
         ----------
         subtitles : List[Subtitle]
             The subtitles to use for the overlays
-        font_family : FontFamily, optional
-            The font to use in all the comic overlays
+        overlay_format : OverlayFormat | list[OverlayFormat], optional
+            The format(s) to use in the overlays. See :meth:`OverlayFormat.normalise` for
+            full details on how formats are resolved.
 
         Returns
         -------
@@ -222,7 +268,11 @@ class ComicStrip(BaseCompuGlobalModel, frozen=False):
             A list of comic overlays
 
         """
-        return [ComicOverlay(text=subtitle.content, font_family=font_family) for subtitle in subtitles]
+        overlay_formats = OverlayFormat.normalise(overlay_format, len(subtitles))
+        return [
+            ComicOverlay.build_with_format(text=subtitle.content, overlay_format=overlay_format)
+            for subtitle, overlay_format in zip(subtitles, overlay_formats, strict=True)
+        ]
 
     def get_encoded(self) -> str:
         """Get the base 64 encoded representation of this comic strip.

--- a/compuglobal/models/overlay.py
+++ b/compuglobal/models/overlay.py
@@ -1,0 +1,109 @@
+"""Helper class for formatting of StreamOverlays and ComicOverlays."""
+
+from dataclasses import dataclass
+
+from compuglobal.models.font import FontAlignment, FontFamily
+
+
+@dataclass(frozen=True)
+class OverlayFormat:
+    """The formatting style to use in an overlay.
+
+    Attributes
+    ----------
+    font_family: FontFamily
+        The font to use for the text in the overlay
+    font_size: int
+        The size of the font in the overlay
+    font_color: list[int]
+        The color of the font as an RGB list [0-255, 0-255, 0-255]
+    text_position_x: int
+        The position of the text on the X-axis
+    text_position_y: int
+        The position of the text on the Y-axis
+    text_alignment: FontAlignment
+        How to align the text of the overlay
+    all_caps: bool
+        Whether to have all text in uppercase
+
+    """
+
+    font_family: FontFamily = FontFamily.IMPACT
+    font_size: int = 0
+    font_color: tuple[int, int, int, int] = (255, 255, 255, 255)
+    text_position_x: int = 50
+    text_position_y: int = 97
+    text_alignment: FontAlignment = FontAlignment.ALIGN_CENTER
+    all_caps: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate font_color is correct.
+
+        Raises
+        ------
+        ValueError
+            If font_colour does not contain 4 values
+        ValueError
+            If font_colour values are not between 0-255)
+
+        """
+        required_rgba_values = 4
+        if len(self.font_color) != required_rgba_values:
+            msg = f"font_color must have exactly 4 values (RGBA), got {len(self.font_color)}"
+            raise ValueError(msg)
+
+        min_color, max_color = 0, 255
+        if not all(min_color <= color <= max_color for color in self.font_color):
+            msg = f"font_color values must be between 0 and 255, got {self.font_color}"
+            raise ValueError(msg)
+
+    @property
+    def font_color_hex(self) -> str:
+        """The font color as a hex string.
+
+        Returns
+        -------
+        str
+            The color hex code
+
+        """
+        r, g, b, a = self.font_color
+        return f"{r:02x}{g:02x}{b:02x}{a:02x}"
+
+    @classmethod
+    def normalise(
+        cls,
+        overlay_format: "OverlayFormat | list[OverlayFormat] | None",
+        size: int,
+    ) -> "list[OverlayFormat]":
+        """Normalise the given overlay formats into a list of given size.
+
+        Parameters
+        ----------
+        overlay_format : OverlayFormat | list[OverlayFormat] | None
+            The format(s) to use in the overlays:
+
+            - If ``None``, default formatting is applied to all overlays
+            - If a single :class:`OverlayFormat`, it is applied to all overlays
+            - If a list, each format is applied to the corresponding overlay in order
+            - If fewer formats are given than subtitles, default formatting is used for the remainder
+            - If more formats are given than subtitles, the extras are ignored
+        size : int
+            The size of the desired list
+
+        Returns
+        -------
+        list[OverlayFormat]
+            The normalised list of formats with the given size
+
+        """
+        if overlay_format is None:
+            return size * [cls()]
+
+        if isinstance(overlay_format, cls):
+            return size * [overlay_format]
+
+        if len(overlay_format) < size:
+            return overlay_format + [cls()] * (size - len(overlay_format))
+
+        return overlay_format[:size]

--- a/compuglobal/models/stream.py
+++ b/compuglobal/models/stream.py
@@ -4,6 +4,7 @@ from pydantic import Field
 
 from compuglobal.models.base import BaseCompuGlobalModel
 from compuglobal.models.font import FontAlignment, FontFamily
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap
 
 
@@ -18,6 +19,8 @@ class StreamOverlay(BaseCompuGlobalModel):
         The font to use for the text in the overlay
     font_size: int
         The size of the font in the overlay
+    font_color: list[int]
+        The color of the font as an RGB list [0-255, 0-255, 0-255]
     text_position_x: int
         The position of the text on the X-axis
     text_position_y: int
@@ -43,6 +46,47 @@ class StreamOverlay(BaseCompuGlobalModel):
     all_caps: bool = Field(alias="all_caps", default=True)
     start: int = Field(alias="start", ge=0)
     end: int = Field(alias="end", ge=0)
+
+    @classmethod
+    def build_with_format(
+        cls,
+        *,
+        text: str,
+        start: int,
+        end: int,
+        overlay_format: OverlayFormat,
+    ) -> "StreamOverlay":
+        """Build a StreamOverlay using an OverlayFormat.
+
+        Parameters
+        ----------
+        text : str
+            The content/text of the subtitle in the overlay
+        start : int
+            The time where the overlay begins
+        end : int
+            The time where the overlay ends
+        overlay_format : OverlayFormat
+            The format to use for all formatting in the overlay
+
+        Returns
+        -------
+        StreamOverlay
+            The overlay with the given formatting
+
+        """
+        return cls(
+            text=text,
+            start=start,
+            end=end,
+            font_family=overlay_format.font_family,
+            font_color=overlay_format.font_color,
+            font_size=overlay_format.font_size,
+            text_position_x=overlay_format.text_position_x,
+            text_position_y=overlay_format.text_position_y,
+            text_alignment=overlay_format.text_alignment,
+            all_caps=overlay_format.all_caps,
+        )
 
 
 class Stream(BaseCompuGlobalModel):
@@ -70,15 +114,21 @@ class Stream(BaseCompuGlobalModel):
     check_only: bool = Field(alias="check_only")
 
     @classmethod
-    def from_screencap(cls, *, screencap: Screencap, font_family: FontFamily = FontFamily.IMPACT) -> "Stream":
+    def from_screencap(
+        cls,
+        *,
+        screencap: Screencap,
+        overlay_format: OverlayFormat | list[OverlayFormat] | None = None,
+    ) -> "Stream":
         """Build a stream using a screencap object.
 
         Parameters
         ----------
         screencap : Screencap
             The screencap to use for the Stream
-        font_family : FontFamily
-            The font to use in any overlays
+        overlay_format : OverlayFormat | list[OverlayFormat], optional
+            The format(s) to use in the overlays. See :meth:`OverlayFormat.normalise` for
+            full details on how formats are resolved.
 
         Returns
         -------
@@ -86,7 +136,7 @@ class Stream(BaseCompuGlobalModel):
             The stream with overlays for the given screencap.
 
         """
-        overlays = cls.build_stream_overlays(screencap, font_family)
+        overlays = cls.build_stream_overlays(screencap, overlay_format)
 
         return cls(
             episode=screencap.episode.key,
@@ -97,15 +147,19 @@ class Stream(BaseCompuGlobalModel):
         )
 
     @staticmethod
-    def build_stream_overlays(screencap: Screencap, font: FontFamily = FontFamily.IMPACT) -> list[StreamOverlay]:
+    def build_stream_overlays(
+        screencap: Screencap,
+        overlay_format: OverlayFormat | list[OverlayFormat] | None = None,
+    ) -> list[StreamOverlay]:
         """Build stream overlays with the given screencap, subtitles, timestamp, and font.
 
         Parameters
         ----------
         screencap: Screencap
-            The screencap to use for hte overlays
-        font : FontFamily, optional
-            The font to use for all overlays
+            The screencap to use for the overlays
+        overlay_format : OverlayFormat | list[OverlayFormat], optional
+            The format(s) to use in the overlays. See :meth:`OverlayFormat.normalise` for
+            full details on how formats are resolved.
 
         Returns
         -------
@@ -113,14 +167,16 @@ class Stream(BaseCompuGlobalModel):
             The built list of overlays for the stream
 
         """
+        overlay_format = OverlayFormat.normalise(overlay_format, len(screencap.subtitles))
+
         return [
-            StreamOverlay(
+            StreamOverlay.build_with_format(
                 text=subtitle.content,
-                font=font,
                 start=subtitle.start_timestamp - screencap.get_start(),
                 end=subtitle.end_timestamp - screencap.get_start(),
+                overlay_format=overlay_format,
             )
-            for subtitle in screencap.subtitles
+            for subtitle, overlay_format in zip(screencap.subtitles, overlay_format, strict=True)
         ]
 
     def get_caption(self) -> str:

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -44,6 +44,12 @@ Subtitle
     :members:
     :exclude-members: model_config
 
+Overlays
+~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: OverlayFormat
+    :members:
+    :exclude-members: model_config
+
 Comics
 ~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: ComicPanel

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,16 +1,39 @@
 """Test API config module."""
 
+from compuglobal import FontAlignment
 from compuglobal.api.config import CompuGlobalAPIConfig
 from compuglobal.models.font import FontFamily
+from compuglobal.models.overlay import OverlayFormat
 
 
 def test_compuglobal_config_defaults() -> None:
     config = CompuGlobalAPIConfig(title="Example")
-    expected = CompuGlobalAPIConfig(title="Example", default_font=FontFamily.IMPACT)
+    default_format = OverlayFormat(
+        font_family=FontFamily.IMPACT,
+        font_size=0,
+        font_color=(255, 255, 255, 255),
+        text_position_x=50,
+        text_position_y=97,
+        text_alignment=FontAlignment.ALIGN_CENTER,
+        all_caps=True,
+    )
+    expected = CompuGlobalAPIConfig(title="Example", default_format=default_format)
     assert config == expected
 
 
 def test_compuglobal_config_overrides() -> None:
-    config = CompuGlobalAPIConfig(title="Test", default_font=FontFamily.AKBAR)
+    custom_format = OverlayFormat(
+        font_family=FontFamily.JOST,
+        font_size=12,
+        font_color=(10, 20, 30, 40),
+        text_position_x=120,
+        text_position_y=80,
+        text_alignment=FontAlignment.ALIGN_LEFT,
+        all_caps=False,
+    )
+    config = CompuGlobalAPIConfig(
+        title="Test",
+        default_format=custom_format,
+    )
     assert config.title == "Test"
-    assert config.default_font == FontFamily.AKBAR
+    assert config.default_format == custom_format

--- a/tests/models/test_comic.py
+++ b/tests/models/test_comic.py
@@ -6,9 +6,10 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import ValidationError
 
-from compuglobal import Screencap
 from compuglobal.models.comic import ComicLayout, ComicOverlay, ComicPanel, ComicStrip
 from compuglobal.models.font import FontAlignment, FontFamily
+from compuglobal.models.overlay import OverlayFormat
+from compuglobal.models.screencap import Screencap
 from compuglobal.models.subtitle import Subtitle
 
 
@@ -81,7 +82,10 @@ def test_comic_overlay_model_with_overrides() -> None:
 
 def test_comic_overlay_from_subtitles(subtitle_json: dict[str, Any]) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     assert overlay.model_dump() == snapshot(
         {
             "t": "Stupid, sexy Flanders!",
@@ -106,7 +110,10 @@ def test_comic_panel_validate_dump_with_defaults() -> None:
 
 def test_comic_panel_validate_dump_with_overrides(subtitle_json: dict[str, Any]) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     payload = {"e": "S01E01", "ts": 7777, "o": [overlay]}
     panel = ComicPanel.model_validate(payload)
     assert panel.model_dump() == snapshot(
@@ -165,7 +172,10 @@ def test_comic_panel_from_screencap(screencap: Screencap) -> None:
 
 
 def test_comic_panel_from_screencap_custom_font(screencap: Screencap) -> None:
-    comic_panel = ComicPanel.from_screencap(screencap=screencap, font=FontFamily.JOST)
+    comic_panel = ComicPanel.from_screencap(
+        screencap=screencap,
+        overlay_format=OverlayFormat(font_family=FontFamily.JOST),
+    )
     assert comic_panel.model_dump() == snapshot(
         {
             "e": "S11E10",
@@ -193,7 +203,10 @@ def test_comic_panel_from_screencap_custom_font(screencap: Screencap) -> None:
 
 def test_comic_panel_get_encoded(subtitle_json: dict[str, Any]) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     payload = {"e": "S01E01", "ts": 7777, "o": [overlay]}
     panel = ComicPanel.model_validate(payload)
 
@@ -205,7 +218,10 @@ def test_comic_panel_get_encoded(subtitle_json: dict[str, Any]) -> None:
 
 def test_comic_strip(subtitle_json: dict[str, Any]) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     payload = {"e": "S01E01", "ts": 7777, "o": [overlay]}
     panel = ComicPanel.model_validate(payload)
     panels = [panel.model_copy(update={"timestamp": panel.timestamp + 1000 * i}) for i in range(4)]
@@ -372,7 +388,10 @@ def test_comic_strip_build_comic_overlays(subtitle_json: dict[str, Any]) -> None
 def test_comic_strip_build_comic_overlays_with_font(subtitle_json: dict[str, Any]) -> None:
     subtitle = Subtitle.model_validate(subtitle_json)
     subtitles = [subtitle.model_copy(update={"content": f"{i} - {subtitle.content}"}) for i in range(1, 4)]
-    overlays = ComicStrip.build_comic_overlays(subtitles=subtitles, font_family=FontFamily.JOST)
+    overlays = ComicStrip.build_comic_overlays(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.JOST),
+    )
     assert overlays == snapshot(
         [
             ComicOverlay(text="1 - Stupid, sexy Flanders!", font_family=FontFamily.JOST),
@@ -404,7 +423,10 @@ def test_comic_strip_default_layouts(
     expected_layout: ComicLayout,
 ) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     payload = {"e": "S01E01", "ts": 7777, "o": [overlay]}
     panel = ComicPanel.model_validate(payload)
     panels = [panel.model_copy(update={"timestamp": panel.timestamp + 1000 * i}) for i in range(panel_count)]
@@ -416,7 +438,10 @@ def test_comic_strip_custom_layout(
     subtitle_json: dict[str, Any],
 ) -> None:
     subtitles = [Subtitle.model_validate(subtitle_json)]
-    overlay = ComicOverlay.from_subtitles(subtitles=subtitles, font_family=FontFamily.AKBAR)
+    overlay = ComicOverlay.from_subtitles(
+        subtitles=subtitles,
+        overlay_format=OverlayFormat(font_family=FontFamily.AKBAR),
+    )
     payload = {"e": "S01E01", "ts": 7777, "o": [overlay]}
     panel = ComicPanel.model_validate(payload)
     panels = [panel.model_copy(update={"timestamp": panel.timestamp + 1000 * i}) for i in range(3)]

--- a/tests/models/test_overlay.py
+++ b/tests/models/test_overlay.py
@@ -1,0 +1,57 @@
+"""Test overlay module."""
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from compuglobal.models.font import FontFamily
+from compuglobal.models.overlay import OverlayFormat
+
+
+def test_overlay_format_invalid_rgba_length_too_few() -> None:
+    with pytest.raises(ValueError, match="must have exactly 4 values"):
+        # pyrefly: ignore [bad-argument-type]
+        OverlayFormat(font_color=())
+
+
+def test_overlay_format_invalid_rgba_length_too_many() -> None:
+    with pytest.raises(ValueError, match="must have exactly 4 values"):
+        # pyrefly: ignore [bad-argument-type]
+        OverlayFormat(font_color=(255, 255, 255, 255, 255))
+
+
+@given(st.integers(max_value=-1))
+def test_overlay_format_invalid_colors_low(bad_color: int) -> None:
+    with pytest.raises(ValueError, match="values must be between 0 and 255"):
+        OverlayFormat(font_color=(1, 1, 1, bad_color))
+
+
+@given(st.integers(min_value=256))
+def test_overlay_format_invalid_colors_high(bad_color: int) -> None:
+    with pytest.raises(ValueError, match="values must be between 0 and 255"):
+        OverlayFormat(font_color=(1, 1, 1, bad_color))
+
+
+def test_overlay_format_normalise_default() -> None:
+    normalised = OverlayFormat.normalise(None, 1)
+    assert len(normalised) == 1
+    assert normalised[0] == OverlayFormat()
+
+
+def test_overlay_format_normalise_given() -> None:
+    given = OverlayFormat(font_family=FontFamily.AKBAR)
+    normalised = OverlayFormat.normalise(given, 1)
+    assert normalised == [given]
+
+
+def test_overlay_format_normalise_given_fewer() -> None:
+    given = OverlayFormat(font_family=FontFamily.AKBAR)
+    default = OverlayFormat()
+    normalised = OverlayFormat.normalise([given], 4)
+    assert normalised == [given, default, default, default]
+
+
+def test_overlay_format_normalise_given_extras() -> None:
+    given = OverlayFormat(font_family=FontFamily.AKBAR)
+    normalised = OverlayFormat.normalise([given] * 10, 4)
+    assert normalised == [given, given, given, given]

--- a/tests/models/test_stream.py
+++ b/tests/models/test_stream.py
@@ -5,6 +5,7 @@ from inline_snapshot import snapshot
 from pydantic import ValidationError
 
 from compuglobal.models.font import FontAlignment, FontFamily
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap
 from compuglobal.models.stream import Stream, StreamOverlay
 
@@ -207,7 +208,7 @@ def test_stream_build_stream_overlays(screencap: Screencap) -> None:
 
 
 def test_stream_build_stream_overlays_font(screencap: Screencap) -> None:
-    overlays = Stream.build_stream_overlays(screencap, font=FontFamily.JOST)
+    overlays = Stream.build_stream_overlays(screencap, overlay_format=OverlayFormat(font_family=FontFamily.JOST))
     assert overlays == snapshot(
         [
             StreamOverlay(

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -15,6 +15,7 @@ from compuglobal.api.config import CompuGlobalAPIConfig
 from compuglobal.errors import NoSearchResultsFoundError
 from compuglobal.models.font import FontFamily
 from compuglobal.models.frame import Frame
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.stream import Stream
 
@@ -24,7 +25,7 @@ class CustomCompuGlobalAPI(AsyncCompuGlobalAPI):
 
     BASE_URL = "https://example.com"
     TITLE = "Testing"
-    DEFAULT_FONT = FontFamily.JOST
+    DEFAULT_FORMAT = OverlayFormat(font_family=FontFamily.JOST)
 
 
 class _InvalidRequestJSONError(Exception):
@@ -65,7 +66,10 @@ def random_frame_results(quantity: int) -> list[dict[str, Any]]:
 async def test_api_defaults() -> None:
     async with aiohttp.ClientSession() as session:
         api = CustomCompuGlobalAPI(session=session)
-        assert api.config == CompuGlobalAPIConfig(title="Testing", default_font=FontFamily.JOST)
+        assert api.config == CompuGlobalAPIConfig(
+            title="Testing",
+            default_format=OverlayFormat(font_family=FontFamily.JOST),
+        )
         assert api.client.base_url == "https://example.com"
 
 
@@ -335,7 +339,7 @@ async def test_api_get_comic_strip_url_custom_subtitles_truncated_subtitles(
 @pytest.mark.asyncio
 async def test_api_get_gif_url(api: CustomCompuGlobalAPI, mock_http: aiointercept, screencap: Screencap) -> None:
     url = api.media.RENDER_GIF.build_encoded_url(api.BASE_URL)
-    stream = Stream.from_screencap(screencap=screencap, font_family=api.DEFAULT_FONT)
+    stream = Stream.from_screencap(screencap=screencap, overlay_format=api.DEFAULT_FORMAT)
     payload = {
         "url": "/video/S02E01/CoCGOx7cJdlKOKjrZoE7S5_mXqw=.gif",
     }
@@ -357,7 +361,7 @@ async def test_api_get_gif_url_custom_subtitles(
     url = api.media.RENDER_GIF.build_encoded_url(api.BASE_URL)
 
     stream_screencap = screencap.model_copy(update={"subtitles": subtitles})
-    stream = Stream.from_screencap(screencap=stream_screencap, font_family=api.DEFAULT_FONT)
+    stream = Stream.from_screencap(screencap=stream_screencap, overlay_format=api.DEFAULT_FORMAT)
 
     payload = {
         "url": "/video/S02E01/CoCGOx7cJdlKOKjrZoE7S5_mXqw=.gif",
@@ -377,7 +381,7 @@ async def test_api_get_gif_url_fallback_comic(
     screencap: Screencap,
 ) -> None:
     url = api.media.RENDER_GIF.build_encoded_url(api.BASE_URL)
-    stream = Stream.from_screencap(screencap=screencap, font_family=api.DEFAULT_FONT)
+    stream = Stream.from_screencap(screencap=screencap, overlay_format=api.DEFAULT_FORMAT)
     payload = {
         "progress": 0.044500000000000005,
     }
@@ -407,7 +411,7 @@ async def test_api_get_gif_url_truncated_subtitles(
     url = api.media.RENDER_GIF.build_encoded_url(api.BASE_URL)
 
     stream_screencap = screencap.model_copy(update={"subtitles": subtitles[:4]})
-    stream = Stream.from_screencap(screencap=stream_screencap, font_family=api.DEFAULT_FONT)
+    stream = Stream.from_screencap(screencap=stream_screencap, overlay_format=api.DEFAULT_FORMAT)
 
     payload = {
         "url": "/video/S02E01/CoCGOx7cJdlKOKjrZoE7S5_mXqw=.gif",


### PR DESCRIPTION
Add OverlayFormat model for all overlay formatting

**Breaking changes:**

Update all class methods to support giving an
overlay_format instead of font_family (removed),
to allow overriding all overlay formatting
options.

Change the CompuGlobalAPIConfig used by all APIs
to specify a default_format (OverlayFormat)
instead of just a default font. This should make
it simpler for applying custom formatting
preferences at the API level.