### PR TITLE
Add basic logging to API calls and validation

### DIFF
--- a/compuglobal/aio.py
+++ b/compuglobal/aio.py
@@ -1,6 +1,7 @@
 """Used for interacting with and building CGHMC APIs."""
 
 import json
+import logging
 from typing import overload
 from warnings import deprecated
 
@@ -20,6 +21,8 @@ from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.stream import Stream
 from compuglobal.models.subtitle import Subtitle
+
+log = logging.getLogger(__name__)
 
 """Contains the async API Wrappers used for accessing all the cghmc API endpoints."""
 
@@ -145,6 +148,13 @@ class AsyncCompuGlobalAPI:
         if len(search_results) > 0:
             return [FrameResult.model_validate(result) for result in search_results]
 
+        log.debug(
+            "No search results found | base_url=%s | search_text=%s | season_minimum=%s | season_maximum=%s",
+            self.BASE_URL,
+            search_text,
+            season_minimum,
+            season_maximum,
+        )
         raise NoSearchResultsFoundError
 
     async def search_for_screencap(
@@ -509,9 +519,13 @@ class AsyncCompuGlobalAPI:
 
         # Use default format if not given
         overlay_format = overlay_format or self.config.default_format
+        if overlay_format != self.config.default_format:
+            log.debug("Using custom overlay format | screencap=%s | overlay_format=%s", screencap, overlay_format)
 
         # Use screencap subtitles if not given
         subtitles = subtitles or screencap.subtitles
+        if subtitles != screencap.subtitles:
+            log.debug("Using custom subtitles | screencap=%s | subtitles=%s", screencap, subtitles)
 
         # Prevent too many subtitles being used
         subtitles = subtitles[: self._MAX_ALLOWED_SUBTITLES]

--- a/compuglobal/api/client.py
+++ b/compuglobal/api/client.py
@@ -1,5 +1,6 @@
 """Module for handling API requests to CGHMC APIs."""
 
+import logging
 from http import HTTPStatus
 from typing import Any
 
@@ -7,6 +8,8 @@ from aiohttp import ClientSession
 
 from compuglobal.api.endpoint import PreparedRequest, RequestMethod
 from compuglobal.errors import APIPageStatusError
+
+log = logging.getLogger(__name__)
 
 
 class CompuGlobalAPIClient:
@@ -48,8 +51,10 @@ class CompuGlobalAPIClient:
         """
         async with self.session.get(url, params=params) as response:
             if HTTPStatus.OK <= response.status < HTTPStatus.MULTIPLE_CHOICES:
+                log.debug("Response %s | GET %s", response.status, url)
                 return await response.json()
 
+            log.error("Non-2xx response %s | GET %s", response.status, url)
             raise APIPageStatusError(response.status, self.base_url)
 
     async def post_data(self, url: str, json: dict[str, Any] | list[Any] | None) -> str:
@@ -75,8 +80,10 @@ class CompuGlobalAPIClient:
         """
         async with self.session.post(url, json=json) as response:
             if HTTPStatus.OK <= response.status < HTTPStatus.MULTIPLE_CHOICES:
+                log.debug("Response %s | POST %s", response.status, url)
                 return await response.text()
 
+            log.error("Non-2xx response %s | POST %s")
             raise APIPageStatusError(response.status, self.base_url)
 
     async def handle_request(self, request: PreparedRequest) -> str | dict[str, Any] | list[Any]:
@@ -93,6 +100,7 @@ class CompuGlobalAPIClient:
             The json response from the API
 
         """
+        log.debug("%s %s | params=%s | body=%s", request.method.value, request.url, request.params, request.body)
         if request.method == RequestMethod.POST:
             return await self.post_data(request.url, json=request.body)
 

--- a/compuglobal/api/endpoint.py
+++ b/compuglobal/api/endpoint.py
@@ -1,5 +1,6 @@
 """Module of endpoint classes used for modelling an API endpoint."""
 
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
@@ -8,6 +9,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
 
 
 class RequestMethod(StrEnum):
@@ -133,8 +136,9 @@ class Endpoint:
         url = self.build_url(base_url, query, path_params)
 
         if len(query.keys()) > 0:
-            return f"{url}?{urlencode(query, doseq=True)}"
+            url = f"{url}?{urlencode(query, doseq=True)}"
 
+        log.debug("Built encoded url %s | base_url=%s | query=%s | path_params=%s", url, base_url, query, path_params)
         return url
 
     def build_request(
@@ -170,6 +174,15 @@ class Endpoint:
         # Get body data
         body_data = body.model_dump() if body is not None else None
 
+        log.debug(
+            "Built %s request | path=%s | query=%s | path_params=%s | body=%s",
+            self.method.value,
+            self.path,
+            query,
+            path_params,
+            body,
+        )
+
         return PreparedRequest(url=new_url, method=self.method, params=query, body=body_data)
 
     def validate_query(self, query: dict[str, Any]) -> None:
@@ -190,10 +203,12 @@ class Endpoint:
         unexpected = query.keys() - (self.required_query_params | self.optional_query_params)
 
         if missing:
+            log.debug("Validation failed for %s | missing required params %s", self.path, missing)
             raise ValueError(
                 _format_validation_error_message(message="Missing query params", values=missing),
             )
         if unexpected:
+            log.debug("Validation failed for %s | unexpected params %s", self.path, unexpected)
             raise ValueError(
                 _format_validation_error_message(message="Unexpected query params", values=unexpected),
             )
@@ -216,9 +231,11 @@ class Endpoint:
         unexpected = path_params.keys() - self.required_path_params
 
         if missing:
+            log.debug("Validation failed for %s | missing required path params %s", self.path, missing)
             raise ValueError(_format_validation_error_message(message="Missing path params", values=missing))
 
         if unexpected:
+            log.debug("Validation failed for %s | unexpected path params %s", self.path, unexpected)
             raise ValueError(
                 _format_validation_error_message(message="Unexpected path params", values=unexpected),
             )

--- a/compuglobal/models/overlay.py
+++ b/compuglobal/models/overlay.py
@@ -1,5 +1,6 @@
 """Helper class for formatting of StreamOverlays and ComicOverlays."""
 
+import dataclasses
 from dataclasses import dataclass
 
 from compuglobal.models.font import FontAlignment, FontFamily
@@ -54,6 +55,12 @@ class OverlayFormat:
         if not all(min_color <= color <= max_color for color in self.font_color):
             msg = f"font_color values must be between 0 and 255, got {self.font_color}"
             raise ValueError(msg)
+
+    def _changed_fields(self) -> dict:
+        return {f.name: getattr(self, f.name) for f in dataclasses.fields(self) if getattr(self, f.name) != f.default}
+
+    def __str__(self) -> str:  # noqa: D105
+        return str(self._changed_fields())
 
     @property
     def font_color_hex(self) -> str:


### PR DESCRIPTION
Add basic logging to:
- All HTTP client methods
- Endpoint validation/building
- Non-default behaviour (custom subtitles/overlay formats)