### PR TITLE
Reorder fonts to match API order

### DIFF
--- a/compuglobal/aio.py
+++ b/compuglobal/aio.py
@@ -70,7 +70,7 @@ class AsyncCompuGlobalAPI:
             chosen_font = extra_fonts[0] if len(extra_fonts) > 0 else FontFamily.IMPACT
             default_format = OverlayFormat(font_family=chosen_font)
 
-        allowed_fonts = FontFamily.universal_fonts() + extra_fonts
+        allowed_fonts = extra_fonts + FontFamily.universal_fonts()
 
         self.config = CompuGlobalAPIConfig(
             title=self.TITLE,

--- a/compuglobal/models/font.py
+++ b/compuglobal/models/font.py
@@ -41,8 +41,8 @@ class FontFamily(StrEnum):
         return [
             FontFamily.IMPACT,
             FontFamily.COMIC_NEUE,
-            FontFamily.JOST,
             FontFamily.PACIFICO,
+            FontFamily.JOST,
         ]
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 
 Changelog
 =========
+
+Upcoming Changes
+----------------
+
+Miscellaneous
+~~~~~~~~~~~~~
+- Reorder fonts in :meth:`FontFamily.universal_fonts` and :attr:`CompuGlobalAPIConfig.allowed_fonts` to match the order used by the API.
+
 0.4.2
 -----
 


### PR DESCRIPTION
Reorder fonts in FontFamily.universal_fonts and CompuGlobalAPIConfig.allowed_fonts to match the order used by the API.