### PR TITLE
Feature improve integration tests

### DIFF
--- a/tests/integration/test_aio_integration.py
+++ b/tests/integration/test_aio_integration.py
@@ -1,6 +1,5 @@
 """Test all API endpoints using aio module with live external APIs (no mocking)."""
 
-import asyncio
 from collections.abc import AsyncGenerator
 
 import aiohttp
@@ -23,12 +22,6 @@ API_SEARCHES: dict[str, str] = {
 }
 API_CLASSES: list[type[AsyncCompuGlobalAPI]] = [Frinkiac, Morbotron, CapitalBeatUs]
 _screencap_cache: dict[str, Screencap] = {}
-
-
-# Sleep between all tests to avoid flooding API
-@pytest_asyncio.fixture(autouse=True)
-async def wait_between_calls() -> None:
-    await asyncio.sleep(1)
 
 
 @pytest_asyncio.fixture(params=API_CLASSES, ids=lambda cls: cls.__name__)
@@ -73,9 +66,6 @@ async def check_content_type_and_url(
 ) -> None:
     for expectation in expected_in_url:
         assert expectation in url
-
-    # Sleep before checking headers
-    await asyncio.sleep(1)
 
     async with session.head(url, allow_redirects=True) as response:
         assert response.status == 200

--- a/tests/integration/test_aio_integration.py
+++ b/tests/integration/test_aio_integration.py
@@ -9,7 +9,9 @@ import pytest_asyncio
 
 from compuglobal.aio import AsyncCompuGlobalAPI, CapitalBeatUs, Frinkiac, Morbotron
 from compuglobal.models.episode import Episode, EpisodeSummary
+from compuglobal.models.font import FontColor, FontFamily
 from compuglobal.models.frame import Frame, FrameResult
+from compuglobal.models.overlay import OverlayFormat
 from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.subtitle import Subtitle
 from tests.integration.conftest import log_customised_media_url, log_media_url
@@ -244,3 +246,34 @@ async def test_api_get_gif_url_custom_subtitles(
     gif_url = await api.get_gif_url(searched_customised_screencap)
     await check_content_type_and_url(api.client.session, gif_url, "image/gif", ["gif"])
     log_customised_media_url(api.config.title, "Custom Gif", gif_url, "image/gif")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_api_get_gif_url_custom_format(
+    api: AsyncCompuGlobalAPI,
+    searched_customised_screencap: Screencap,
+) -> None:
+    overlay_formats = [
+        OverlayFormat(
+            font_family=FontFamily.JOST,
+            font_size=16,
+            font_color=FontColor.from_hex("ff00ff"),
+            all_caps=False,
+        ),
+        OverlayFormat(
+            font_family=FontFamily.IMPACT,
+            font_size=36,
+            font_color=FontColor.from_hex("ffff00"),
+            all_caps=True,
+        ),
+        OverlayFormat(
+            font_family=FontFamily.COMIC_NEUE,
+            font_size=64,
+            font_color=FontColor.from_hex("00ff00"),
+            all_caps=False,
+        ),
+    ]
+    gif_url = await api.get_gif_url(searched_customised_screencap, overlay_format=overlay_formats)
+    await check_content_type_and_url(api.client.session, gif_url, "image/gif", ["gif"])
+    log_customised_media_url(api.config.title, "Custom Formatted Gif", gif_url, "image/gif")

--- a/tests/integration/test_aio_integration.py
+++ b/tests/integration/test_aio_integration.py
@@ -14,7 +14,12 @@ from compuglobal.models.screencap import Screencap, ScreencapMoment
 from compuglobal.models.subtitle import Subtitle
 from tests.integration.conftest import log_customised_media_url, log_media_url
 
-API_CLASSES = [Frinkiac, Morbotron, CapitalBeatUs]
+API_SEARCHES: dict[str, str] = {
+    "Frinkiac": "nothing at all",
+    "Morbotron": "shut up and take my money",
+    "CapitalBeatUs": "decisions are made",
+}
+API_CLASSES: list[type[AsyncCompuGlobalAPI]] = [Frinkiac, Morbotron, CapitalBeatUs]
 _screencap_cache: dict[str, Screencap] = {}
 
 
@@ -32,21 +37,23 @@ async def api(request: pytest.FixtureRequest) -> AsyncGenerator[AsyncCompuGlobal
 
 
 @pytest_asyncio.fixture
-async def random_screencap(api: AsyncCompuGlobalAPI) -> Screencap:
+async def searched_screencap(api: AsyncCompuGlobalAPI) -> Screencap:
     class_name = type(api).__name__
     if class_name not in _screencap_cache:
-        random_screencap = await api.get_random_screencap()
-        _screencap_cache[class_name] = random_screencap
+        search_text = API_SEARCHES.get(class_name, "random")
+        searched_screencap = await api.search_for_screencap(search_text)
+        _screencap_cache[class_name] = searched_screencap
 
     return _screencap_cache[class_name]
 
 
 @pytest_asyncio.fixture
-async def random_customised_screencap(api: AsyncCompuGlobalAPI) -> Screencap:
+async def searched_customised_screencap(api: AsyncCompuGlobalAPI) -> Screencap:
     class_name = type(api).__name__
     if class_name not in _screencap_cache:
-        random_screencap = await api.get_random_screencap()
-        _screencap_cache[class_name] = random_screencap
+        search_text = API_SEARCHES.get(class_name, "random")
+        searched_screencap = await api.search_for_screencap(search_text)
+        _screencap_cache[class_name] = searched_screencap
 
     screencap = _screencap_cache[class_name]
     subtitles = [
@@ -83,16 +90,19 @@ async def test_api_get_random_screencap(api: AsyncCompuGlobalAPI) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_screencap_episode_timestamp(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    screencap = await api.get_screencap(episode=random_screencap.frame.key, timestamp=random_screencap.frame.timestamp)
-    assert random_screencap == screencap
+async def test_api_get_screencap_episode_timestamp(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    screencap = await api.get_screencap(
+        episode=searched_screencap.frame.key,
+        timestamp=searched_screencap.frame.timestamp,
+    )
+    assert searched_screencap == screencap
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_screencap_frame(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    screencap = await api.get_screencap(episode=random_screencap.key, timestamp=random_screencap.timestamp)
-    assert random_screencap == screencap
+async def test_api_get_screencap_frame(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    screencap = await api.get_screencap(episode=searched_screencap.key, timestamp=searched_screencap.timestamp)
+    assert searched_screencap == screencap
 
 
 @pytest.mark.asyncio
@@ -129,10 +139,10 @@ async def test_api_browse_episode(api: AsyncCompuGlobalAPI) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_transcript(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
+async def test_api_get_transcript(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
     transcript = await api.get_transcript(
-        episode=random_screencap.frame.key,
-        timestamp=random_screencap.frame.timestamp,
+        episode=searched_screencap.frame.key,
+        timestamp=searched_screencap.frame.timestamp,
     )
     assert len(transcript) > 0
     for caption in transcript:
@@ -159,10 +169,10 @@ async def test_api_navigator(api: AsyncCompuGlobalAPI) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_frames(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
+async def test_api_get_frames(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
     frames = await api.get_frames(
-        key=random_screencap.frame.key,
-        timestamp=random_screencap.frame.timestamp,
+        key=searched_screencap.frame.key,
+        timestamp=searched_screencap.frame.timestamp,
         before=0,
         after=99999999,
     )
@@ -173,16 +183,16 @@ async def test_api_get_frames(api: AsyncCompuGlobalAPI, random_screencap: Screen
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_image_url(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    image_url = await api.get_image_url(random_screencap)
+async def test_api_get_image_url(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    image_url = await api.get_image_url(searched_screencap)
     await check_content_type_and_url(api.client.session, image_url, "image/jpeg", ["jpg"])
     log_media_url(api.config.title, "Default Image", image_url, "image/jpeg")
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_comic_panel_url(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    comic_panel_url = await api.get_comic_panel_url(random_screencap)
+async def test_api_get_comic_panel_url(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    comic_panel_url = await api.get_comic_panel_url(searched_screencap)
     await check_content_type_and_url(api.client.session, comic_panel_url, "image/jpeg", ["comic"])
     log_media_url(api.config.title, "Default Comic Panel", comic_panel_url, "image/jpeg")
 
@@ -191,17 +201,17 @@ async def test_api_get_comic_panel_url(api: AsyncCompuGlobalAPI, random_screenca
 @pytest.mark.integration
 async def test_api_get_comic_panel_url_custom_subtitles(
     api: AsyncCompuGlobalAPI,
-    random_customised_screencap: Screencap,
+    searched_customised_screencap: Screencap,
 ) -> None:
-    comic_panel_url = await api.get_comic_panel_url(random_customised_screencap)
+    comic_panel_url = await api.get_comic_panel_url(searched_customised_screencap)
     await check_content_type_and_url(api.client.session, comic_panel_url, "image/jpeg", ["comic"])
     log_customised_media_url(api.config.title, "Custom Comic Panel", comic_panel_url, "image/jpeg")
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_comic_strip_url(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    comic_strip_url = await api.get_comic_strip_url(random_screencap)
+async def test_api_get_comic_strip_url(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    comic_strip_url = await api.get_comic_strip_url(searched_screencap)
     await check_content_type_and_url(api.client.session, comic_strip_url, "image/jpeg", ["comic", "layout"])
     log_media_url(api.config.title, "Default Comic Strip", comic_strip_url, "image/jpeg")
 
@@ -210,17 +220,17 @@ async def test_api_get_comic_strip_url(api: AsyncCompuGlobalAPI, random_screenca
 @pytest.mark.integration
 async def test_api_get_comic_strip_url_custom_subtitles(
     api: AsyncCompuGlobalAPI,
-    random_customised_screencap: Screencap,
+    searched_customised_screencap: Screencap,
 ) -> None:
-    comic_strip_url = await api.get_comic_strip_url(random_customised_screencap)
+    comic_strip_url = await api.get_comic_strip_url(searched_customised_screencap)
     await check_content_type_and_url(api.client.session, comic_strip_url, "image/jpeg", ["comic", "layout"])
     log_customised_media_url(api.config.title, "Custom Comic Strip", comic_strip_url, "image/jpeg")
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_api_get_gif_url(api: AsyncCompuGlobalAPI, random_screencap: Screencap) -> None:
-    gif_url = await api.get_gif_url(random_screencap)
+async def test_api_get_gif_url(api: AsyncCompuGlobalAPI, searched_screencap: Screencap) -> None:
+    gif_url = await api.get_gif_url(searched_screencap)
     await check_content_type_and_url(api.client.session, gif_url, "image/gif", ["gif"])
     log_media_url(api.config.title, "Default Gif", gif_url, "image/gif")
 
@@ -229,8 +239,8 @@ async def test_api_get_gif_url(api: AsyncCompuGlobalAPI, random_screencap: Scree
 @pytest.mark.integration
 async def test_api_get_gif_url_custom_subtitles(
     api: AsyncCompuGlobalAPI,
-    random_customised_screencap: Screencap,
+    searched_customised_screencap: Screencap,
 ) -> None:
-    gif_url = await api.get_gif_url(random_customised_screencap)
+    gif_url = await api.get_gif_url(searched_customised_screencap)
     await check_content_type_and_url(api.client.session, gif_url, "image/gif", ["gif"])
     log_customised_media_url(api.config.title, "Custom Gif", gif_url, "image/gif")


### PR DESCRIPTION
Use searched screencaps in integration tests, this allows the tests to take advantage of avoiding rate limits as generating gifs that have been generated previously do not have rate limits.

This reduces integration test times from ~120s to ~20s.

Add an additional integration test for generating a gif with customised subtitle formatting (font, color, size, uppercase/lowercase)

Removing the sleeps from the tests will causes tests to fail with 429 if the gifs are eventually removed, so the HTTP client will need some retrying capability to prevent this in future.